### PR TITLE
Enable Clerk provider in auth config

### DIFF
--- a/convex/auth.config.ts
+++ b/convex/auth.config.ts
@@ -1,14 +1,14 @@
 const authConfig = {
   providers: [
     // Uncomment this once you have set up a Clerk app
-    // {
-    //   // Replace with your own Clerk Issuer URL from your "convex" JWT template
-    //   // or with `process.env.CLERK_JWT_ISSUER_DOMAIN`
-    //   // and configure CLERK_JWT_ISSUER_DOMAIN on the Convex Dashboard
-    //   // See https://docs.convex.dev/auth/clerk#configuring-dev-and-prod-instances
-    //   domain: process.env.CLERK_JWT_ISSUER_DOMAIN,
-    //   applicationID: "convex",
-    // },
+    {
+      // Replace with your own Clerk Issuer URL from your "convex" JWT template
+      // or with `process.env.CLERK_JWT_ISSUER_DOMAIN`
+      // and configure CLERK_JWT_ISSUER_DOMAIN on the Convex Dashboard
+      // See https://docs.convex.dev/auth/clerk#configuring-dev-and-prod-instances
+      domain: process.env.CLERK_JWT_ISSUER_DOMAIN,
+      applicationID: "convex",
+    },
   ],
 };
 


### PR DESCRIPTION
Uncommented and activated the Clerk provider configuration in convex/auth.config.ts, allowing authentication via Clerk using the domain from the environment variable.